### PR TITLE
Document base CUDA Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: base-cuda
+
+base-cuda:
+	docker build -t decoder/base-cuda -f docker/base/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # decoder-yolox
+
+This repository contains Docker build files for the video-processing pipeline described in the project documentation. The images target Ubuntu 22.04 with NVIDIA GPUs and Python 3.10.
+
+## Docker Images
+
+### `decoder/base-cuda`
+- **Purpose:** Provides CUDA 12.2 runtime along with Python 3.10 and basic scientific libraries for GPU-accelerated video processing.
+- **GPU required:** Yes. Enable with `--gpus all` when running.
+
+#### Build example
+```bash
+make base-cuda
+# or
+docker build -t decoder/base-cuda -f docker/base/Dockerfile .
+```
+
+#### Run example
+```bash
+docker run --gpus all -it decoder/base-cuda bash
+```
+
+#### Dependencies / volumes
+- Optional: mount a working directory with `-v $(pwd):/data` to access local files inside the container.
+
+#### Parameters
+This base image exposes no additional parameters. It is intended as a foundation for other services in the pipeline.

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+        python3.10 python3.10-venv python3-pip git ffmpeg libsm6 libxext6 \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --upgrade pip wheel setuptools
+# Torch + базові наукові пакети
+RUN pip install torch==2.3.*+cu122 torchvision==0.18.*+cu122 --index-url https://download.pytorch.org/whl/cu122
+RUN pip install opencv-python-headless==4.* numpy scipy tqdm typer==0.9
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- add README instructions for the new CUDA base image

## Testing
- `make base-cuda` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b796a7e34832f93b98a6fb916b80c