### PR TITLE
Add extractor service for frame extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,29 @@ docker run --gpus all -it decoder/base-cuda bash
 
 #### Parameters
 This base image exposes no additional parameters. It is intended as a foundation for other services in the pipeline.
+
+### `decoder/extractor`
+- **Purpose:** Extracts PNG frames from a video file.
+- **GPU required:** No.
+
+#### Build example
+```bash
+make extractor
+# or
+docker build -t decoder/extractor -f services/extractor/Dockerfile .
+```
+
+#### Run example
+```bash
+docker run --rm -v $(pwd)/data:/data decoder/extractor \
+    --video /data/match.mp4 --out /data/frames --fps 30
+```
+
+#### Dependencies / volumes
+- Mount a working directory with `-v $(pwd)/data:/data` to supply video
+  files and collect frames.
+
+#### Parameters
+- `--video` (required) – path to the source video.
+- `--out` (required) – directory where frames will be saved.
+- `--fps` (default: `30`) – output frame rate.

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -10,12 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: base-cuda
-
-base-cuda:
-	docker build -t decoder/base-cuda -f docker/base/Dockerfile .
-
-.PHONY: extractor
-
-extractor:
-docker build -t decoder/extractor -f services/extractor/Dockerfile .
+FROM decoder/base-cuda
+COPY extract_frames.py /app/
+ENTRYPOINT ["python3", "/app/extract_frames.py"]

--- a/services/extractor/extract_frames.py
+++ b/services/extractor/extract_frames.py
@@ -1,0 +1,82 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Frame extraction utility for video files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import cv2
+from tqdm import tqdm
+
+
+def extract_frames(video: str, out_dir: str, fps: int) -> int:
+    """Extract frames from a video at the desired FPS.
+
+    Args:
+        video: Path to the input video file.
+        out_dir: Directory where frames will be written as PNGs.
+        fps: Target frames per second for extraction.
+
+    Returns:
+        Number of frames written to ``out_dir``.
+    """
+    cap = cv2.VideoCapture(video)
+    if not cap.isOpened():
+        raise FileNotFoundError(f"Unable to open video: {video}")
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    video_fps = cap.get(cv2.CAP_PROP_FPS)
+    if video_fps <= 0:
+        video_fps = fps
+    step = max(int(round(video_fps / fps)), 1)
+
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    frame_idx = 0
+    written = 0
+    with tqdm(total=total_frames, desc="Extracting frames", unit="frame") as pbar:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if frame_idx % step == 0:
+                filename = Path(out_dir) / f"{written:06d}.png"
+                cv2.imwrite(str(filename), frame)
+                written += 1
+            frame_idx += 1
+            pbar.update(1)
+
+    cap.release()
+    return written
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Extract frames from a video")
+    parser.add_argument("--video", required=True, help="Path to input video")
+    parser.add_argument("--out", required=True, help="Directory for output frames")
+    parser.add_argument("--fps", type=int, default=30, help="Output frames per second")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    count = extract_frames(args.video, args.out, args.fps)
+    print(f"Saved {count} frames to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_frames.py
+++ b/tests/test_extract_frames.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for extract_frames module."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from services.extractor.extract_frames import extract_frames
+
+
+def create_test_video(path: Path, frame_count: int = 10, fps: int = 10) -> None:
+    """Create a simple test video with blank frames."""
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, (64, 64))
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    for _ in range(frame_count):
+        writer.write(frame)
+    writer.release()
+
+
+def test_extract_frames(tmp_path: Path) -> None:
+    video = tmp_path / "test.mp4"
+    out_dir = tmp_path / "out"
+    create_test_video(video, frame_count=10, fps=10)
+
+    count = extract_frames(str(video), str(out_dir), fps=5)
+    assert count == 5
+    extracted = sorted(p.name for p in out_dir.glob("*.png"))
+    assert len(extracted) == 5
+    assert extracted[0] == "000000.png"


### PR DESCRIPTION
## Summary
- add `decoder/extractor` service with Dockerfile
- implement `extract_frames.py` for saving PNG frames from video
- provide pytest for extractor module
- document extractor service in README
- add build target in Makefile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688b7e59df04832f8401d52867323076