### PR TITLE
Pin PyTorch versions for CUDA image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains Docker build files for the video-processing pipeline de
 ### `decoder/base-cuda`
 - **Purpose:** Provides CUDA 12.2 runtime along with Python 3.10 and basic scientific libraries for GPU-accelerated video processing.
 - **GPU required:** Yes. Enable with `--gpus all` when running.
+- **Packages:** Python 3.10 with PyTorch 2.3.0 + CUDA 12.2, torchvision 0.18.0, OpenCV, NumPy, SciPy, tqdm and typer.
 
 #### Build example
 ```bash

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip install --upgrade pip wheel setuptools
 # Torch + базові наукові пакети
-RUN pip install torch==2.3.*+cu122 torchvision==0.18.*+cu122 --index-url https://download.pytorch.org/whl/cu122
+RUN pip install torch==2.3.0+cu122 torchvision==0.18.0+cu122 --index-url https://download.pytorch.org/whl/cu122
 RUN pip install opencv-python-headless==4.* numpy scipy tqdm typer==0.9
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- pin the PyTorch and torchvision versions in the base CUDA Dockerfile
- document installed packages in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688b82958a44832f87dcc2c640ada076