### PR TITLE
Fix Makefile indentation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ base-cuda:
 .PHONY: extractor
 
 extractor:
-docker build -t decoder/extractor -f services/extractor/Dockerfile .
+	docker build -t decoder/extractor -f services/extractor/Dockerfile .


### PR DESCRIPTION
## Summary
- fix missing tab on `extractor` target so `make extractor` runs

## Testing
- `make base-cuda` *(fails: docker not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688b8398bd48832f993e73091cd386cf