### PR TITLE
Update CUDA base image to 12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This repository contains Docker build files for the video-processing pipeline de
 ## Docker Images
 
 ### `decoder/base-cuda`
-- **Purpose:** Provides CUDA 12.2 runtime along with Python 3.10 and basic scientific libraries for GPU-accelerated video processing.
+- **Purpose:** Provides CUDA 12.1 runtime along with Python 3.10 and basic scientific libraries for GPU-accelerated video processing.
 - **GPU required:** Yes. Enable with `--gpus all` when running.
-- **Packages:** Python 3.10 with PyTorch 2.3.0 + CUDA 12.2, torchvision 0.18.0, OpenCV, NumPy, SciPy, tqdm and typer.
+- **Packages:** Python 3.10 with PyTorch 2.2.2 + CUDA 12.1, torchvision 0.17.2, OpenCV, NumPy, SciPy, tqdm and typer.
 
 #### Build example
 ```bash

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,13 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
         python3.10 python3.10-venv python3-pip git ffmpeg libsm6 libxext6 \
     && rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip install --upgrade pip wheel setuptools
 # Torch + базові наукові пакети
-RUN pip install torch==2.3.0+cu122 torchvision==0.18.0+cu122 --index-url https://download.pytorch.org/whl/cu122
+RUN pip install torch==2.2.2+cu121 torchvision==0.17.2+cu121 --index-url https://download.pytorch.org/whl/cu121
 RUN pip install opencv-python-headless==4.* numpy scipy tqdm typer==0.9
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- use CUDA 12.1 runtime in the base Docker image
- install PyTorch 2.2.2+cu121 and torchvision 0.17.2
- document updated CUDA runtime and libraries in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688b8640f6a0832fb0def0a6ca6ddf35