### PR TITLE
Fix Dockerfile path for extractor service

### DIFF
--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -11,5 +11,6 @@
 # limitations under the License.
 
 FROM decoder/base-cuda
-COPY extract_frames.py /app/
+# Copy the frame extraction script from the build context.
+COPY services/extractor/extract_frames.py /app/extract_frames.py
 ENTRYPOINT ["python3", "/app/extract_frames.py"]


### PR DESCRIPTION
## Summary
- fix COPY path in `services/extractor/Dockerfile` so build context works

## Testing
- `make extractor` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688b8d151c34832fa04396d173609a42