### PR TITLE
Fix invalid commit in court_detector Dockerfile

### DIFF
--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -16,7 +16,7 @@ ARG WEIGHTS_URL="https://drive.google.com/uc?id=1f-Co64ehgq4uddcQm1aFBDtbnyZhQvg
 
 # Install TennisCourtDetector from GitHub at a fixed commit.
 RUN pip install --no-cache-dir \
-    git+https://github.com/yastrebksv/TennisCourtDetector@e2d35bf \
+    git+https://github.com/yastrebksv/TennisCourtDetector@e5cd4f1 \
     gdown \
     && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
## Summary
- fix broken commit URL for the TennisCourtDetector dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbc309810832fab1a76d3cbeab502