### PR TITLE
Fix Dockerfile for court detector

### DIFF
--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir gdown && rm -rf /root/.cache/pip
 
 RUN git clone --depth 1 https://github.com/yastrebksv/TennisCourtDetector /tmp/TennisCourtDetector
 
-COPY /tmp/TennisCourtDetector/tennis_court_detector /app/tennis_court_detector
+RUN cp -r /tmp/TennisCourtDetector/tennis_court_detector /app/
 
 # Download pretrained weights.
 RUN mkdir -p /opt/weights \
@@ -29,7 +29,7 @@ RUN mkdir -p /opt/weights \
     || (echo "Weights file not usable as PyTorch model." && exit 1)
 
 ENV TCD_WEIGHTS=/opt/weights/model.pt
-ENV PYTHONPATH="/app:$PYTHONPATH"
+ENV PYTHONPATH=/app
 
 COPY services/court_detector/calibrate.py /app/calibrate.py
 


### PR DESCRIPTION
## Summary
- fix invalid copy command for the TennisCourtDetector sources
- simplify PYTHONPATH environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbec28cc4832f8b403a4667fc4b80