### PR TITLE
Fix Docker weight validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker build -t decoder/court-detector -f services/court_detector/Dockerfile .
 ```
 
 Weights are downloaded automatically during the build phase.
-Model format: PyTorch `.pt` file (validated at build-time).
+Model format: PyTorch `.pt` file (validated at build-time with `map_location="cpu"`).
 The upstream repository is reorganized at build time so that
 `tennis_court_detector` is available as a regular Python package.
 

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /app/tennis_court_detector && \
 RUN mkdir -p /opt/weights \
     && gdown "$WEIGHTS_URL" -O /opt/weights/model.pt \
     && test -s /opt/weights/model.pt || (echo "Weights download failed" && exit 1) \
-    && python3 -c 'import torch; torch.load("/opt/weights/model.pt")' \
+    && python3 -c 'import torch; torch.load("/opt/weights/model.pt", map_location="cpu")' \
     || (echo "Weights file not usable as PyTorch model." && exit 1)
 
 ENV TCD_WEIGHTS=/opt/weights/model.pt


### PR DESCRIPTION
## Summary
- update court-detector Dockerfile to load weights on CPU
- document CPU weight validation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd8d0e510832f8dfb6bf5af721b06