### PR TITLE
Fix court-detector build

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ docker build -t decoder/court-detector -f services/court_detector/Dockerfile .
 Weights are downloaded automatically during the build phase.
 Model format: PyTorch `.pt` file (validated at build-time with `map_location="cpu"`).
 The upstream repository is reorganized at build time so that
-`tennis_court_detector` is available as a regular Python package.
+`tennis_court_detector` is available as a regular Python package. The
+`__init__.py` created during the build exports `CourtDetector` from
+`infer_in_image` since the original `tracknet` module does not define
+the class.
+NumPy is pinned below version 2 for runtime compatibility with PyTorch.
 
 #### Run example
 ```bash

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -14,8 +14,8 @@ FROM decoder/base-cuda
 
 ARG WEIGHTS_URL="https://drive.google.com/uc?id=1f-Co64ehgq4uddcQm1aFBDtbnyZhQvgG"
 
-# Install gdown and clone TennisCourtDetector (no setup.py available)
-RUN pip install --no-cache-dir gdown && rm -rf /root/.cache/pip
+# Install gdown and pin NumPy below 2 for PyTorch compatibility
+RUN pip install --no-cache-dir 'numpy<2' gdown && rm -rf /root/.cache/pip
 
 RUN git clone --depth 1 https://github.com/boog9/TennisCourtDetector /tmp/TennisCourtDetector
 
@@ -31,7 +31,7 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/utils.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/base_trainer.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/base_validator.py /app/tennis_court_detector/ && \
-    printf 'from .tracknet import CourtDetector\n' > /app/tennis_court_detector/__init__.py
+    printf 'from .infer_in_image import CourtDetector\n' > /app/tennis_court_detector/__init__.py
 
 # Download pretrained weights.
 RUN mkdir -p /opt/weights \


### PR DESCRIPTION
## Summary
- pin NumPy below version 2 in the Dockerfile
- export `CourtDetector` from `infer_in_image`
- document the patched export in README
- clarify Dockerfile comment about NumPy pinning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c70c531ac832f9c0f7d86c86317bb