### PR TITLE
Fix court-detector import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The upstream repository is reorganized at build time so that
 `__init__.py` created during the build exports `CourtDetector` from
 `infer_in_image` since the original `tracknet` module does not define
 the class.
+Import statements in `infer_in_image.py` are also patched to use package-
+relative imports (e.g. `from .tracknet import BallTrackerNet`) to avoid
+`ModuleNotFoundError` at runtime.
 NumPy is pinned below version 2 for runtime compatibility with PyTorch.
 
 #### Run example

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -27,6 +27,13 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/court_reference.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/homography.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/infer_in_image.py /app/tennis_court_detector/ && \
+    sed -i \
+        -e 's/^from tracknet /from .tracknet /' \
+        -e 's/^from postprocess /from .postprocess /' \
+        -e 's/^from court_reference /from .court_reference /' \
+        -e 's/^from homography /from .homography /' \
+        -e 's/^from utils /from .utils /' \
+        /app/tennis_court_detector/infer_in_image.py && \
     cp /tmp/TennisCourtDetector/infer_in_video.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/utils.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/base_trainer.py /app/tennis_court_detector/ && \


### PR DESCRIPTION
## Summary
- patch import paths inside infer_in_image.py using sed
- note the patch in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c73a96094832fb458669c0b360879