### PR TITLE
Fix tcd postprocess import

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ the class.
 Import statements in `infer_in_image.py` are also patched to use package-
 relative imports (e.g. `from .tracknet import BallTrackerNet`) to avoid
 `ModuleNotFoundError` at runtime.
+`postprocess.py` is similarly patched so that it imports from `.utils`.
 NumPy is pinned below version 2 for runtime compatibility with PyTorch.
 
 #### Run example

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -40,6 +40,9 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/base_validator.py /app/tennis_court_detector/ && \
     printf 'from .infer_in_image import CourtDetector\n' > /app/tennis_court_detector/__init__.py
 
+# Patch imports in postprocess.py to use package-relative utils module
+RUN sed -i 's/^from utils /from .utils /' /app/tennis_court_detector/postprocess.py
+
 # Download pretrained weights.
 RUN mkdir -p /opt/weights \
     && gdown "$WEIGHTS_URL" -O /opt/weights/model.pt \


### PR DESCRIPTION
## Summary
- patch `postprocess.py` in the court detector image so that it uses package-relative import
- document this patch in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c76635078832f8a57b06d7d8c320f