### PR TITLE
Patch homography import in court-detector Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Import statements in `infer_in_image.py` are also patched to use package-
 relative imports (e.g. `from .tracknet import BallTrackerNet`) to avoid
 `ModuleNotFoundError` at runtime.
 `postprocess.py` is similarly patched so that it imports from `.utils`.
+`homography.py` is patched so that it imports from `.court_reference`.
 NumPy is pinned below version 2 for runtime compatibility with PyTorch.
 
 #### Run example

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -43,6 +43,9 @@ RUN mkdir -p /app/tennis_court_detector && \
 # Patch imports in postprocess.py to use package-relative utils module
 RUN sed -i 's/^from utils /from .utils /' /app/tennis_court_detector/postprocess.py
 
+# Patch imports in homography.py to use package-relative court_reference module
+RUN sed -i 's/^from court_reference /from .court_reference /' /app/tennis_court_detector/homography.py
+
 # Download pretrained weights.
 RUN mkdir -p /opt/weights \
     && gdown "$WEIGHTS_URL" -O /opt/weights/model.pt \


### PR DESCRIPTION
## Summary
- fix homography import path in the court-detector Dockerfile
- document new patch step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c79def7a8832fb59fe0c8a0a275c7