### PR TITLE
Fix missing matplotlib in court detector image

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ relative imports (e.g. `from .tracknet import BallTrackerNet`) to avoid
 `ModuleNotFoundError` at runtime.
 `postprocess.py` is similarly patched so that it imports from `.utils`.
 `homography.py` is patched so that it imports from `.court_reference`.
-NumPy is pinned below version 2 for runtime compatibility with PyTorch.
+NumPy is pinned below version 2 for runtime compatibility with PyTorch, and
+matplotlib is installed for utilities in `court_reference.py`.
 
 #### Run example
 ```bash

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -14,8 +14,8 @@ FROM decoder/base-cuda
 
 ARG WEIGHTS_URL="https://drive.google.com/uc?id=1f-Co64ehgq4uddcQm1aFBDtbnyZhQvgG"
 
-# Install gdown and pin NumPy below 2 for PyTorch compatibility
-RUN pip install --no-cache-dir 'numpy<2' gdown && rm -rf /root/.cache/pip
+# Install gdown, matplotlib and pin NumPy below 2 for PyTorch compatibility
+RUN pip install --no-cache-dir 'numpy<2' gdown matplotlib && rm -rf /root/.cache/pip
 
 RUN git clone --depth 1 https://github.com/boog9/TennisCourtDetector /tmp/TennisCourtDetector
 


### PR DESCRIPTION
## Summary
- install matplotlib in `decoder/court-detector` image
- document matplotlib requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7add6e58832fa725fd2bdca7c01f