### PR TITLE
Fix CourtDetector future import

### DIFF
--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -30,6 +30,7 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/homography.py /app/tennis_court_detector/ && \
     cp /tmp/TennisCourtDetector/infer_in_image.py /app/tennis_court_detector/ && \
     cat /tmp/infer_patch.py >> /app/tennis_court_detector/infer_in_image.py && \
+    sed -i '1s;^;from __future__ import annotations\n;' /app/tennis_court_detector/infer_in_image.py && \
     sed -i \
         -e 's/^from tracknet /from .tracknet /' \
         -e 's/^from postprocess /from .postprocess /' \

--- a/services/court_detector/infer_in_image_patch.py
+++ b/services/court_detector/infer_in_image_patch.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 """Patch for TennisCourtDetector with bbox extraction utilities."""
 
-from __future__ import annotations
-
 from typing import Dict, List
 
 import cv2


### PR DESCRIPTION
## Summary
- ensure `from __future__ import annotations` is inserted at the top of `infer_in_image.py`
- drop duplicate future import from patch script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c80249878832fb1e27fb1477300e7