### PR TITLE
Fix CourtDetector to use updated BallTrackerNet

### DIFF
--- a/services/court_detector/infer_in_image.py
+++ b/services/court_detector/infer_in_image.py
@@ -9,7 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Patch for TennisCourtDetector with bbox extraction utilities."""
+"""Court detection utilities for a single image."""
+
+from __future__ import annotations
 
 from typing import Dict, List
 
@@ -21,7 +23,7 @@ import torch
 def extract_bounding_boxes(
     output: torch.Tensor | np.ndarray, threshold: float = 0.5
 ) -> List[List[int]]:
-    """Extract bounding boxes from model output.
+    """Extract bounding boxes from a heatmap output.
 
     Args:
         output: Raw output tensor from ``BallTrackerNet``.

--- a/tests/test_infer_in_image_patch.py
+++ b/tests/test_infer_in_image_patch.py
@@ -16,7 +16,7 @@ import pytest
 cv2 = pytest.importorskip("cv2")
 np = pytest.importorskip("numpy")
 
-from services.court_detector.infer_in_image_patch import extract_bounding_boxes
+from services.court_detector.infer_in_image import extract_bounding_boxes
 
 
 def test_extract_bounding_boxes_simple() -> None:


### PR DESCRIPTION
## Summary
- switch to `infer_in_image.py` with proper import of `BallTrackerNet`
- update tests to import from the new module

## Testing
- `pytest -q`
- `make court-detector` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb499b654832f9114b19cb75aad40