### PR TITLE
Fix court-detector build to include patched infer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ docker build -t decoder/court-detector -f services/court_detector/Dockerfile .
 Weights are downloaded automatically during the build phase.
 Model format: PyTorch `.pt` file (validated at build-time with `map_location="cpu"`).
 The upstream repository is reorganized at build time so that
-`tennis_court_detector` is available as a regular Python package. The build
-adds a small `CourtDetector` implementation directly into
-`infer_in_image.py` so that it can be imported by `calibrate.py`.
-`__init__.py` simply re-exports this class for convenience. The wrapper
+`tennis_court_detector` is available as a regular Python package. After
+copying the upstream sources, the Dockerfile overwrites `infer_in_image.py`
+with the patched version from this repository so that `calibrate.py` can
+import `CourtDetector` without issues. `__init__.py` simply re-exports this
+class for convenience. The wrapper
 exposes ``detect(frame: np.ndarray)`` which returns the model's 15-channel
 heatmaps as a NumPy array.
 Import statements in `infer_in_image.py` are also patched to use package-

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -42,6 +42,10 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/base_validator.py /app/tennis_court_detector/ && \
     printf 'from .infer_in_image import CourtDetector\n' > /app/tennis_court_detector/__init__.py
 
+# Overwrite with the patched infer_in_image implementation so calibrate.py
+# can import CourtDetector without errors.
+COPY services/court_detector/infer_in_image.py /app/tennis_court_detector/infer_in_image.py
+
 # Patch imports in postprocess.py to use package-relative utils module
 RUN sed -i 's/^from utils /from .utils /' /app/tennis_court_detector/postprocess.py
 


### PR DESCRIPTION
## Summary
- copy the patched `infer_in_image.py` during the court-detector image build
- clarify README to mention overwriting the upstream script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc4f26100832fa1c0c6607eb22dc6