### PR TITLE
Fix tracknet copy in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Weights are downloaded automatically during the build phase.
 Model format: PyTorch `.pt` file (validated at build-time with `map_location="cpu"`).
 The upstream repository is reorganized at build time so that
 `tennis_court_detector` is available as a regular Python package. After
-copying the upstream sources, the Dockerfile overwrites `infer_in_image.py`
-with the patched version from this repository so that `calibrate.py` can
+copying the upstream sources, the Dockerfile overwrites both `tracknet.py` and
+`infer_in_image.py` with patched versions from this repository. The custom
+`tracknet.py` exposes a 15-channel `BallTrackerNet`, and `calibrate.py` can
 import `CourtDetector` without issues. `__init__.py` simply re-exports this
 class for convenience. The wrapper
 exposes ``detect(frame: np.ndarray)`` which returns the model's 15-channel

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -42,6 +42,9 @@ RUN mkdir -p /app/tennis_court_detector && \
     cp /tmp/TennisCourtDetector/base_validator.py /app/tennis_court_detector/ && \
     printf 'from .infer_in_image import CourtDetector\n' > /app/tennis_court_detector/__init__.py
 
+# Overwrite tracknet.py to ensure 15 output channels
+COPY services/court_detector/tracknet.py /app/tennis_court_detector/tracknet.py
+
 # Overwrite with the patched infer_in_image implementation so calibrate.py
 # can import CourtDetector without errors.
 COPY services/court_detector/infer_in_image.py /app/tennis_court_detector/infer_in_image.py


### PR DESCRIPTION
## Summary
- overwrite upstream tracknet.py with patched version
- document tracknet patch in README

## Testing
- `pytest -q`
- `make court-detector` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc78e5344832f937c4ac19baa3329