### PR TITLE
Apply conv18 kernel fix

### DIFF
--- a/services/court_detector/tracknet.py
+++ b/services/court_detector/tracknet.py
@@ -65,7 +65,8 @@ class BallTrackerNet(nn.Module):
         self.conv15 = ConvBlock(512, 512)
         self.conv16 = ConvBlock(512, 512)
         self.conv17 = ConvBlock(512, 512)
-        self.conv18 = ConvBlock(512, 15, kernel_size=1, padding=0)
+        # Останній шар повинен бути 3×3, padding=1 — так, як у офіційних ваг
+        self.conv18 = ConvBlock(512, 15)  # kernel_size=3, padding=1 за замовчуванням
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover
         x = self.conv1(x)


### PR DESCRIPTION
## Summary
- adjust final conv block to use 3x3 padding=1 and comment

## Testing
- `pytest -q`
- `DOCKER_BUILDKIT=1 docker build --no-cache -t decoder/court-detector -f services/court_detector/Dockerfile .` *(fails: command not found)*
- `docker run --gpus all --rm -v $(pwd)/data:/data decoder/court-detector --frame data/frames_min/000000.png --out data/court_meta.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf560bd88832fb72a15e47429b97d