### PR TITLE
Sync tracknet and add update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,13 @@ The output JSON additionally contains `frame_id`, `timestamp_ms`, `model_sha`, a
 `device`, plus a `heatmaps` array with 15 channels. If the optional
 `postprocess.py` utilities are available, a `homography` matrix is also
 included.
+
+### `update-tracknet.sh`
+- **Purpose:** Synchronizes `tracknet.py` with the official TennisCourtDetector repository,
+  rebuilds the `decoder/court-detector` image without cache and performs a smoke test.
+- **GPU required:** Yes for the smoke test. Enable with `--gpus all`.
+
+#### Usage example
+```bash
+./update-tracknet.sh
+```

--- a/services/court_detector/tracknet.py
+++ b/services/court_detector/tracknet.py
@@ -55,18 +55,18 @@ class BallTrackerNet(nn.Module):
         self.conv5 = ConvBlock(128, 256)
         self.conv6 = ConvBlock(256, 256)
         self.conv7 = ConvBlock(256, 256)
-        self.conv8 = ConvBlock(256, 256)
-        self.conv9 = ConvBlock(256, 512)
+        # === Official weight channel widths ===
+        self.conv8 = ConvBlock(256, 512)
+        self.conv9 = ConvBlock(512, 512)
         self.conv10 = ConvBlock(512, 512)
-        self.conv11 = ConvBlock(512, 512)
-        self.conv12 = ConvBlock(512, 512)
-        self.conv13 = ConvBlock(512, 512)
-        self.conv14 = ConvBlock(512, 512)
-        self.conv15 = ConvBlock(512, 512)
-        self.conv16 = ConvBlock(512, 512)
-        self.conv17 = ConvBlock(512, 512)
-        # Останній шар повинен бути 3×3, padding=1 — так, як у офіційних ваг
-        self.conv18 = ConvBlock(512, 15)  # kernel_size=3, padding=1 за замовчуванням
+        self.conv11 = ConvBlock(512, 256)
+        self.conv12 = ConvBlock(256, 256)
+        self.conv13 = ConvBlock(256, 256)
+        self.conv14 = ConvBlock(256, 128)
+        self.conv15 = ConvBlock(128, 128)
+        self.conv16 = ConvBlock(128, 64)
+        self.conv17 = ConvBlock(64, 64)
+        self.conv18 = ConvBlock(64, 15)  # 3×3, padding=1
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover
         x = self.conv1(x)

--- a/update-tracknet.sh
+++ b/update-tracknet.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script synchronizes tracknet.py with the official TennisCourtDetector
+# repository and rebuilds the court-detector Docker image with the updated
+# files. It then performs a smoke test to verify correct loading of the
+# weights and validates the convolution channel widths.
+
+set -euo pipefail
+
+##############################################
+# 0. Context
+# Repository: decoder-yolox
+# Service:    services/court_detector
+# Base image: decoder/base-cuda
+##############################################
+
+############### 1. Sync tracknet.py ###############
+curl -sSL https://raw.githubusercontent.com/yastrebksv/TennisCourtDetector/main/tracknet.py \
+     -o services/court_detector/tracknet.py
+
+############### 2. Patch channel CFG ###############
+apply_patch <<'PATCH'
+*** Begin Patch
+*** Update File: services/court_detector/tracknet.py
+@@
+-        self.conv8 = ConvBlock(256, 256)
+-        self.conv9 = ConvBlock(256, 512)
+-        self.conv10 = ConvBlock(512, 512)
+-        self.conv11 = ConvBlock(512, 512)
+-        self.conv12 = ConvBlock(512, 512)
+-        self.conv13 = ConvBlock(512, 512)
+-        self.conv14 = ConvBlock(512, 512)
+-        self.conv15 = ConvBlock(512, 512)
+-        self.conv16 = ConvBlock(512, 512)
+-        self.conv17 = ConvBlock(512, 512)
+-        self.conv18 = ConvBlock(512, 15)
++        # === Official weight channel widths ===
++        self.conv8  = ConvBlock(256, 512)
++        self.conv9  = ConvBlock(512, 512)
++        self.conv10 = ConvBlock(512, 512)
++        self.conv11 = ConvBlock(512, 256)
++        self.conv12 = ConvBlock(256, 256)
++        self.conv13 = ConvBlock(256, 256)
++        self.conv14 = ConvBlock(256, 128)
++        self.conv15 = ConvBlock(128, 128)
++        self.conv16 = ConvBlock(128,  64)
++        self.conv17 = ConvBlock( 64,  64)
++        self.conv18 = ConvBlock( 64,  15)  # 3×3, padding=1
+*** End Patch
+PATCH
+
+############### 3. Fix relative imports ###############
+sed -i 's/^from utils /from .utils /'     services/court_detector/postprocess.py
+sed -i 's/^from court_reference /from .court_reference /' \
+       services/court_detector/homography.py
+
+############### 4. Rebuild Docker (NO CACHE!) ###############
+DOCKER_BUILDKIT=1 docker build --no-cache \
+  -t decoder/court-detector \
+  -f services/court_detector/Dockerfile .
+
+############### 5. Smoke-test ###############
+docker run --gpus all --rm -v $(pwd)/data:/data decoder/court-detector \
+  --frame data/frames_min/000000.png \
+  --out   data/court_meta.json
+
+############### 6. Channel-list sanity check ###############
+docker run --rm --entrypoint "" decoder/court-detector \
+  python - <<'PY'
+import tennis_court_detector.tracknet as t
+ch = [getattr(t.BallTrackerNet(), f'conv{i}').block[0].out_channels for i in range(1,19)]
+print('Conv outs \u2192', ch)
+assert ch == [64,64,128,128,256,256,256,512,512,512,256,256,256,128,128,64,64,15], "Channel list mismatch!"
+PY
+##############################################
+# If the script prints no AssertionError and court_meta.json is created,
+# the integration is up to date with the official TennisCourtDetector.
+##############################################


### PR DESCRIPTION
## Summary
- sync `tracknet.py` conv channel widths with upstream
- add `update-tracknet.sh` for one-step synchronization and smoke testing
- document the update script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf747259c832fbe072ef218b1cd10