### PR TITLE
Fix inference eval setup

### DIFF
--- a/services/court_detector/infer_in_image.py
+++ b/services/court_detector/infer_in_image.py
@@ -60,10 +60,11 @@ class CourtDetector:
             raise RuntimeError("CUDA requested but not available")
 
         self.device = torch.device(device)
-        self.model = BallTrackerNet()
+        # Load network weights directly on the target device
+        self.model = BallTrackerNet().to(self.device)
         state = torch.load(weights_path, map_location=self.device)
         self.model.load_state_dict(state)
-        self.model.to(self.device)
+        # ➜ inference only: disable gradients and ensure eval mode
         self.model.eval()
 
     def detect(self, frame: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- ensure BallTrackerNet loads on the target device and runs in eval mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf99c7c20832fa6229ca5f739713d