### PR TITLE
Disable print in calibrate

### DIFF
--- a/services/court_detector/calibrate.py
+++ b/services/court_detector/calibrate.py
@@ -114,7 +114,8 @@ def main(argv: list[str] | None = None) -> None:
     """CLI entrypoint."""
     args = parse_args(argv)
     meta = calibrate(args.frame, args.out, args.weights, args.device)
-    print(json.dumps(meta))
+    # DEBUG-print disabled — use logger if needed
+    # print(json.dumps(meta, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove noisy JSON output from `calibrate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfdf1b31c832f84f6352abbca53f7