### PR TITLE
Fix tracknet channel comment

### DIFF
--- a/services/court_detector/tracknet.py
+++ b/services/court_detector/tracknet.py
@@ -55,7 +55,7 @@ class BallTrackerNet(nn.Module):
         self.conv5 = ConvBlock(128, 256)
         self.conv6 = ConvBlock(256, 256)
         self.conv7 = ConvBlock(256, 256)
-        # === Official weight channel widths ===
+        # Official weight cfg: 256→512 bottleneck, then narrow back to 64 channels
         self.conv8 = ConvBlock(256, 512)
         self.conv9 = ConvBlock(512, 512)
         self.conv10 = ConvBlock(512, 512)


### PR DESCRIPTION
## Summary
- clarify that the official BallTrackerNet weights narrow back to 64 channels

## Testing
- `pytest -q`
- `DOCKER_BUILDKIT=1 docker build --no-cache -t decoder/court-detector -f services/court_detector/Dockerfile .` *(fails: command not found)*
- `docker run --gpus all --rm -v $(pwd)/data:/data decoder/court-detector --frame data/frames_min/000000.png --out /data/court_meta.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d022956f0832f94e0d153263c7328