### PR TITLE
feat: drop heatmaps from court calibration output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ docker run --rm -v $(pwd)/data:/data decoder/court-detector \
 - `--weights` (optional) – path to the model weights; defaults to `/opt/weights/model.pt`.
 - `--device` (optional) – `auto`, `cpu`, or `cuda`; defaults to `auto`.
 
-The output JSON additionally contains `frame_id`, `timestamp_ms`, `model_sha`, and
-`device`, plus a `heatmaps` array with 15 channels. If the optional
-`postprocess.py` utilities are available, a `homography` matrix is also
-included.
+The output JSON includes `frame_id`, `timestamp_ms`, `model_sha`, and `device`.
+If the optional postprocessing utilities are available, refined `court_points`
+and a `homography` matrix are added. Heatmaps are no longer stored in the
+metadata output.
 
 ### `update-tracknet.sh`
 - **Purpose:** Synchronizes `tracknet.py` with the official TennisCourtDetector repository,


### PR DESCRIPTION
## Summary
- rewrite court calibration to omit heatmaps and optionally add court_points and homography
- document updated court-detector JSON metadata without heatmaps

## Testing
- `pytest`
- `DOCKER_BUILDKIT=1 docker build --no-cache -t decoder/court-detector -f services/court_detector/Dockerfile .` *(fails: command not found: docker)*
- `docker run --gpus all --rm -v $(pwd)/data:/data decoder/court-detector --frame data/frames_min/000000.png --out /data/court_meta.json` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68907ee7a710832f97a957f380a995c8