### PR TITLE
Make TennisCourtDetector ref configurable in court-detector image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+TCD_REF ?= main
+
 .PHONY: base-cuda
 
 base-cuda:
@@ -23,4 +25,4 @@ extractor:
 
 .PHONY: court-detector
 court-detector:
-	docker build -t decoder/court-detector services/court_detector
+	docker build --build-arg TCD_REF=$(TCD_REF) -t decoder/court-detector services/court_detector

--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -25,11 +25,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Clone upstream TennisCourtDetector at a fixed commit for reproducibility
-ARG TCD_COMMIT=3e0743cd5a3ad0a09345d9ae9953ccb209c82e91
+# Clone upstream TennisCourtDetector at a configurable ref (default: main)
+ARG TCD_REF=main
 RUN git clone https://github.com/yastrebksv/TennisCourtDetector.git /app/TennisCourtDetector \
     && cd /app/TennisCourtDetector \
-    && git checkout ${TCD_COMMIT}
+    && git checkout ${TCD_REF} \
+    && test -f infer_in_image.py
 
 # Python deps: use upstream requirements + non-GUI OpenCV. Avoid legacy pins.
 # PyTorch is already preinstalled in the base image; strip any torch deps first.


### PR DESCRIPTION
## Summary
- default TennisCourtDetector checkout to main and allow overriding via TCD_REF
- pass TCD_REF build arg from Makefile
- add simple sanity check after cloning

## Testing
- `pytest`
- `make court-detector` *(fails: docker: No such file or directory)*
- `make TCD_REF=3e0743cd5a3ad0a09345d9ae9953ccb209c82e91 court-detector` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898710fafac832fa4300f806fb782eb