### PR TITLE
fix: stabilize court detector wrapper

### DIFF
--- a/services/court_detector/Dockerfile
+++ b/services/court_detector/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_PREFER_BINARY=1
-ENV PYTHONPATH="/app/TennisCourtDetector:${PYTHONPATH}"
+ENV PYTHONPATH=/app/TennisCourtDetector
 
 # System deps (git, ffmpeg for video frames if needed)
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- silence BuildKit PYTHONPATH warning
- simplify TennisCourtDetector CLI invocation with debug gating

## Testing
- `pytest -q`
- `docker build --build-arg TCD_REF=main -t decoder/court-detector services/court_detector` *(fails: command not found: docker)*
- `docker run --rm --gpus all -v "$PWD/data:/data" decoder/court-detector --frame /data/frames_min/000000.png --out /data/court_meta.json --device cuda` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68988509df04832fb6b88b0b951e561d